### PR TITLE
src/cbor.h: add missing include

### DIFF
--- a/src/cbor.h
+++ b/src/cbor.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#include <sys/types.h>
 
 #define CBOR_CHECK_RET(enc)            \
 if ((written = (enc)) < 0) {           \


### PR DESCRIPTION
`#include <sys/types.h>` is missing when building for embedded target.