### PR TITLE
CMakeLists: add support for clang-tidy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,22 @@ option(EDHOC_USE_LSAN "Use leak sanitizers" ON)
 option(EDHOC_USE_USAN "Use undefined sanitizers" ON)
 option(EDHOC_USE_MSAN "Use memory sanitizers" OFF)
 option(EDHOC_BUILD_FUZZ_TARGETS "Compile fuzz targets" OFF)
+option(EDHOC_CLANG_TIDY "Build with clang-tidy" OFF)
+option(EDHOC_CLANG_TIDY_WERROR "clang-tidy treats warnings as errors" OFF)
+
+
+if (EDHOC_CLANG_TIDY)
+   if (EDHOC_CLANG_TIDY_WERROR)
+        set(CMAKE_C_CLANG_TIDY
+            clang-tidy;
+            -checks=*;
+            -warnings-as-errors=*;)
+    else ()
+        set(CMAKE_C_CLANG_TIDY
+            clang-tidy;
+            -checks=*;)
+    endif()
+endif ()
 
 if (BUILD_SHARED_LIBS)
     set(BUILD_STATIC_LIBS OFF)

--- a/src/crypto/tinycrypt/CMakeLists.txt
+++ b/src/crypto/tinycrypt/CMakeLists.txt
@@ -1,0 +1,1 @@
+set(CMAKE_C_CLANG_TIDY "")

--- a/src/edhoc.c
+++ b/src/edhoc.c
@@ -169,11 +169,13 @@ int edhoc_load_ephkey(edhoc_ctx_t *ctx, const uint8_t *ephKey, size_t ephKeyLen)
 }
 
 static size_t store_conn_id(uint8_t *storage, const uint8_t *conn_id, size_t conn_id_len) {
-    if (conn_id_len > EDHOC_CID_LEN)
+    if (conn_id_len > EDHOC_CID_LEN) {
         return EDHOC_ERR_BUFFER_OVERFLOW;
+    }
 
-    if (conn_id == NULL && conn_id_len != 0)
+    if (conn_id == NULL || conn_id_len != 0) {
         return EDHOC_ERR_BUFFER_OVERFLOW;
+    }
 
     memcpy(storage, conn_id, conn_id_len);
 

--- a/src/format.c
+++ b/src/format.c
@@ -165,7 +165,7 @@ int format_msg1_decode(edhoc_msg1_t *msg1, const uint8_t *in, size_t ilen) {
     uint8_t suite;
 
     size_t i;
-    uint8_t receivedSuites[10];
+    uint8_t receivedSuites[10] = {0};
 
     const uint8_t *p;
 


### PR DESCRIPTION
This PR adds support for running clang-tidy on the code base. It's currently very verbose.