### PR TITLE
src/format: fix wrong cid reference

### DIFF
--- a/src/format.c
+++ b/src/format.c
@@ -300,7 +300,7 @@ int format_msg2_decode(edhoc_msg2_t *msg2,
             EDHOC_FAIL(EDHOC_ERR_CBOR_DECODING);
         }
     } else {
-        msg2->data2.cidr.length = 0;
+        msg2->data2.cidi.length = 0;
     }
 
     if (suite == NULL) {


### PR DESCRIPTION
Could it be that cidi should be set to 0 instead of cidr? @TimothyClaeys 