### PR TITLE
src/format: fix wrong type declaration

### DIFF
--- a/src/format.c
+++ b/src/format.c
@@ -170,8 +170,8 @@ int format_msg1_decode(edhoc_msg1_t *msg1, const uint8_t *in, size_t ilen) {
     const uint8_t *p;
 
 #if defined(NANOCBOR)
-    nanocbor_encoder_t decoder;
-    nanocbor_encoder_t arr;
+    nanocbor_value_t decoder;
+    nanocbor_value_t arr;
 #else
 #error "No CBOR backend enabled"
 #endif
@@ -278,7 +278,7 @@ int format_msg2_decode(edhoc_msg2_t *msg2,
     const uint8_t *p;
 
 #if defined(NANOCBOR)
-    nanocbor_encoder_t decoder;
+    nanocbor_value_t decoder;
 #else
 #error "No CBOR backend enabled"
 #endif
@@ -367,7 +367,7 @@ int format_msg3_decode(edhoc_msg3_t *msg3, corr_t corr, const uint8_t *msg3_buf,
     int ret;
 
 #if defined(NANOCBOR)
-    nanocbor_encoder_t decoder;
+    nanocbor_value_t decoder;
 #else
 #error "No CBOR backend enabled"
 #endif


### PR DESCRIPTION
This PR fixes a sneaky bug in `src/format`, should be evident when looking at it but was quite tricky to find out, with this https://github.com/RIOT-OS/RIOT/pull/16295 passes on `nrf52840` as well now.