### PR TITLE
treewide: include wolffsl/options.h only when required

### DIFF
--- a/examples/coap/init-sign-x509-coap.c
+++ b/examples/coap/init-sign-x509-coap.c
@@ -16,7 +16,9 @@
 
 #if defined(WOLFSSL)
 
+#ifndef WOLFSSL_USER_SETTINGS
 #include <wolfssl/options.h>
+#endif
 #include <wolfssl/wolfcrypt/sha256.h>
 
 #elif defined(HACL)

--- a/examples/coap/init-static-rpk-coap.c
+++ b/examples/coap/init-static-rpk-coap.c
@@ -6,7 +6,9 @@
 
 #if defined(WOLFSSL)
 
+#ifndef WOLFSSL_USER_SETTINGS
 #include <wolfssl/options.h>
+#endif
 #include <wolfssl/wolfcrypt/sha256.h>
 
 #elif defined(HACL)

--- a/examples/coap/resp-sign-x509-coap.c
+++ b/examples/coap/resp-sign-x509-coap.c
@@ -23,7 +23,9 @@
 
 #if defined(WOLFSSL)
 
+#ifndef WOLFSSL_USER_SETTINGS
 #include <wolfssl/options.h>
+#endif
 #include <wolfssl/wolfcrypt/sha256.h>
 
 #elif defined(HACL)

--- a/examples/coap/resp-static-rpk-coap.c
+++ b/examples/coap/resp-static-rpk-coap.c
@@ -13,7 +13,9 @@
 
 #if defined(WOLFSSL)
 
+#ifndef WOLFSSL_USER_SETTINGS
 #include <wolfssl/options.h>
+#endif
 #include <wolfssl/wolfcrypt/sha256.h>
 
 #elif defined(HACL)

--- a/examples/tcp/init-sign-x509-tcp.c
+++ b/examples/tcp/init-sign-x509-tcp.c
@@ -10,7 +10,9 @@
 #include <edhoc/creddb.h>
 
 #if defined(WOLFSSL)
+#ifndef WOLFSSL_USER_SETTINGS
 #include <wolfssl/options.h>
+#endif
 #include <wolfssl/wolfcrypt/sha256.h>
 #elif defined(HACL)
 

--- a/examples/tcp/resp-sign-x509-tcp.c
+++ b/examples/tcp/resp-sign-x509-tcp.c
@@ -18,7 +18,9 @@
 #endif
 
 #if defined(WOLFSSL)
+#ifndef WOLFSSL_USER_SETTINGS
 #include <wolfssl/options.h>
+#endif
 #include <wolfssl/wolfcrypt/sha256.h>
 #elif defined(HACL)
 

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -4,7 +4,9 @@
 
 #if defined(WOLFSSL)
 
+#ifndef WOLFSSL_USER_SETTINGS
 #include <wolfssl/options.h>
+#endif
 #include <wolfssl/wolfcrypt/sha256.h>
 
 #elif defined(HACL)

--- a/src/crypto/wolfssl.c
+++ b/src/crypto/wolfssl.c
@@ -6,7 +6,9 @@
 #if defined(WOLFSSL)
 
 // do not remove
+#ifndef WOLFSSL_USER_SETTINGS
 #include <wolfssl/options.h>
+#endif
 
 #include <wolfssl/wolfcrypt/curve25519.h>
 #include <wolfssl/wolfcrypt/hmac.h>

--- a/test/test_crypto.c
+++ b/test/test_crypto.c
@@ -8,7 +8,9 @@
 
 #if defined(WOLFSSL)
 
+#ifndef WOLFSSL_USER_SETTINGS
 #include <wolfssl/options.h>
+#endif
 #include <wolfssl/wolfcrypt/random.h>
 
 #endif /* WOLFSSL */

--- a/test/test_process.c
+++ b/test/test_process.c
@@ -18,7 +18,9 @@
 
 #if defined(WOLFSSL)
 
+#ifndef WOLFSSL_USER_SETTINGS
 #include <wolfssl/options.h>
+#endif
 #include <wolfssl/wolfcrypt/sha256.h>
 
 #elif defined(HACL)


### PR DESCRIPTION
This PR adds ifdef where needed so that `wolfssl/options.h` is not included when options are set through USER_SETTINGS.