### PR TITLE
src: user string.h instead of memory.h

### DIFF
--- a/src/cbor/nanocbor.c
+++ b/src/cbor/nanocbor.c
@@ -2,8 +2,8 @@
 
 #if defined(NANOCBOR)
 
+#include <string.h>
 #include <nanocbor/nanocbor.h>
-#include <memory.h>
 
 #endif
 

--- a/src/crypto/tinycrypt.c
+++ b/src/crypto/tinycrypt.c
@@ -1,4 +1,4 @@
-#include <memory.h>
+#include <string.h>
 
 #include "edhoc/cose.h"
 #include "edhoc/edhoc.h"


### PR DESCRIPTION
The `memory` header is not available in all embedded arch, so use `string` instead.