### PR TITLE
src/cbor/nanocbor: bump nanocbor version

### DIFF
--- a/cmake/nanocbor.cmake
+++ b/cmake/nanocbor.cmake
@@ -7,7 +7,7 @@ endif ()
 ExternalProject_Add(
         nanocbor-backend
         GIT_REPOSITORY https://github.com/bergzand/NanoCBOR.git
-        GIT_TAG master
+        GIT_TAG 7728af0633a8d9d119c9b36a5c5a441e11e75ff1
         GIT_PROGRESS TRUE
         INSTALL_DIR ${CMAKE_BINARY_DIR}/3rdparty/nanocbor-build
         SOURCE_DIR ${CMAKE_BINARY_DIR}/3rdparty/nanocbor

--- a/src/cbor/nanocbor.c
+++ b/src/cbor/nanocbor.c
@@ -10,39 +10,39 @@
 #if defined(NANOCBOR)
 
 void cbor_init_decoder(cbor_decoder_t *decoder, const uint8_t *buffer, size_t len) {
-    nanocbor_decoder_init((nanocbor_value_t *) decoder, buffer, len);
+    nanocbor_decoder_init(decoder, buffer, len);
 }
 
 int8_t cbor_get_bstr(cbor_decoder_t *decoder, const uint8_t **buffer, size_t *len) {
-    if (nanocbor_get_bstr((nanocbor_value_t *) decoder, buffer, len) == NANOCBOR_OK)
+    if (nanocbor_get_bstr(decoder, buffer, len) == NANOCBOR_OK)
         return CBOR_SUCCESS;
     else
         return CBOR_FAILED;
 }
 
 int8_t cbor_get_uint8_t(cbor_decoder_t *decoder, uint8_t *value) {
-    if (nanocbor_get_uint8((nanocbor_value_t *) decoder, value) > 0)
+    if (nanocbor_get_uint8(decoder, value) > 0)
         return CBOR_SUCCESS;
     else
         return CBOR_FAILED;
 }
 
 int8_t cbor_get_tstr(cbor_decoder_t *decoder, const uint8_t **tstr, size_t *len) {
-    if (nanocbor_get_tstr((nanocbor_value_t *) decoder, tstr, len) == NANOCBOR_OK)
+    if (nanocbor_get_tstr(decoder, tstr, len) == NANOCBOR_OK)
         return CBOR_SUCCESS;
     else
         return CBOR_FAILED;
 }
 
 int8_t cbor_get_int8_t(cbor_decoder_t *decoder, int8_t *value) {
-    if (nanocbor_get_int8((nanocbor_value_t *) decoder, value) > 0)
+    if (nanocbor_get_int8(decoder, value) > 0)
         return CBOR_SUCCESS;
     else
         return CBOR_FAILED;
 }
 
 int8_t cbor_get_int32_t(cbor_decoder_t *decoder, int32_t *value) {
-    if (nanocbor_get_int32((nanocbor_value_t *) decoder, value) > 0)
+    if (nanocbor_get_int32(decoder, value) > 0)
         return CBOR_SUCCESS;
     else
         return CBOR_FAILED;
@@ -54,7 +54,7 @@ uint8_t cbor_get_array(cbor_decoder_t *decoder, uint8_t *arr, size_t *len) {
 
     nanocbor_value_t array;
 
-    if (nanocbor_enter_array((nanocbor_value_t *) decoder, &array) != NANOCBOR_OK)
+    if (nanocbor_enter_array(decoder, &array) != NANOCBOR_OK)
         return CBOR_FAILED;
 
     while (!nanocbor_at_end(&array)) {
@@ -68,7 +68,7 @@ uint8_t cbor_get_array(cbor_decoder_t *decoder, uint8_t *arr, size_t *len) {
 int8_t cbor_get_type(cbor_decoder_t *decoder) {
     uint8_t type;
 
-    switch (nanocbor_get_type((nanocbor_value_t *) decoder)) {
+    switch (nanocbor_get_type(decoder)) {
         case NANOCBOR_TYPE_UINT:
             type = CBOR_UINT;
             break;
@@ -105,7 +105,7 @@ int8_t cbor_map_from_int_int(cbor_decoder_t *decoder, int8_t key, int8_t *value)
     int32_t current_key;
     nanocbor_value_t map;
 
-    if (nanocbor_enter_map((nanocbor_value_t *) decoder, &map) != NANOCBOR_OK)
+    if (nanocbor_enter_map(decoder, &map) != NANOCBOR_OK)
         return CBOR_FAILED;
 
     while (!nanocbor_at_end(&map)) {
@@ -137,7 +137,7 @@ int8_t cbor_map_from_tstr_tstr(cbor_decoder_t *decoder, const char *key, const c
     size_t key_len;
     nanocbor_value_t map;
 
-    if (nanocbor_enter_map((nanocbor_value_t *) decoder, &map) != NANOCBOR_OK)
+    if (nanocbor_enter_map(decoder, &map) != NANOCBOR_OK)
         return CBOR_FAILED;
 
     while (!nanocbor_at_end(&map)) {
@@ -168,7 +168,7 @@ int8_t cbor_map_from_int_bytes(cbor_decoder_t *decoder, int8_t key, const uint8_
     int8_t current_key;
     nanocbor_value_t map;
 
-    if (nanocbor_enter_map((nanocbor_value_t *) decoder, &map) != NANOCBOR_OK)
+    if (nanocbor_enter_map(decoder, &map) != NANOCBOR_OK)
         return CBOR_FAILED;
 
     while (!nanocbor_at_end(&map)) {
@@ -222,19 +222,11 @@ bool cbor_at_end(cbor_decoder_t *decoder) {
 }
 
 void cbor_init_encoder(cbor_encoder_t *encoder, uint8_t *buffer, size_t len) {
-    nanocbor_encoder_init((nanocbor_encoder_t *) encoder, buffer, len);
-}
-
-int8_t cbor_put_bstr(cbor_encoder_t *encoder, const uint8_t *bytes, size_t len) {
-    if (nanocbor_put_bstr(encoder, bytes, len) == NANOCBOR_OK) {
-        return CBOR_SUCCESS;
-    } else {
-        return CBOR_FAILED;
-    }
+    nanocbor_encoder_init(encoder, buffer, len);
 }
 
 int8_t cbor_put_uint(cbor_encoder_t *encoder, unsigned int value) {
-    if (nanocbor_fmt_uint((nanocbor_encoder_t *) encoder, value) == NANOCBOR_OK) {
+    if (nanocbor_fmt_uint(encoder, value) >= 0) {
         return CBOR_SUCCESS;
     } else {
         return CBOR_FAILED;
@@ -242,7 +234,7 @@ int8_t cbor_put_uint(cbor_encoder_t *encoder, unsigned int value) {
 }
 
 int8_t cbor_put_int(cbor_encoder_t *encoder, int value) {
-    if (nanocbor_fmt_int((nanocbor_encoder_t *) encoder, value) == NANOCBOR_OK) {
+    if (nanocbor_fmt_int(encoder, value) >= 0) {
         return CBOR_SUCCESS;
     } else {
         return CBOR_FAILED;
@@ -250,7 +242,7 @@ int8_t cbor_put_int(cbor_encoder_t *encoder, int value) {
 }
 
 int8_t cbor_put_array(cbor_encoder_t *encoder, size_t elements) {
-    if (nanocbor_fmt_array((nanocbor_encoder_t *) encoder, elements) == NANOCBOR_OK) {
+    if (nanocbor_fmt_array(encoder, elements) >= 0) {
         return CBOR_SUCCESS;
     } else {
         return CBOR_FAILED;
@@ -258,7 +250,7 @@ int8_t cbor_put_array(cbor_encoder_t *encoder, size_t elements) {
 }
 
 int8_t cbor_put_map(cbor_encoder_t *encoder, size_t elements) {
-    if (nanocbor_fmt_map((nanocbor_encoder_t *) encoder, elements) == NANOCBOR_OK) {
+    if (nanocbor_fmt_map(encoder, elements) >= 0 ) {
         return CBOR_SUCCESS;
     } else {
         return CBOR_FAILED;
@@ -266,7 +258,15 @@ int8_t cbor_put_map(cbor_encoder_t *encoder, size_t elements) {
 }
 
 int8_t cbor_put_tstr(cbor_encoder_t *encoder, const char *tstr) {
-    if (nanocbor_put_tstr((nanocbor_encoder_t *) encoder, tstr) == NANOCBOR_OK) {
+    if (nanocbor_put_tstr(encoder, tstr) == NANOCBOR_OK ) {
+        return CBOR_SUCCESS;
+    } else {
+        return CBOR_FAILED;
+    }
+}
+
+int8_t cbor_put_bstr(cbor_encoder_t *encoder, const uint8_t *bytes, size_t len) {
+    if (nanocbor_put_bstr(encoder, bytes, len) == NANOCBOR_OK) {
         return CBOR_SUCCESS;
     } else {
         return CBOR_FAILED;
@@ -282,7 +282,7 @@ int8_t cbor_start_bstr(cbor_encoder_t *encoder, uint16_t elements) {
 }
 
 size_t cbor_encoded_len(cbor_encoder_t *encoder) {
-    return nanocbor_encoded_len((nanocbor_encoder_t *) encoder);
+    return nanocbor_encoded_len(encoder);
 }
 
 int8_t cbor_skip(cbor_decoder_t *decoder) {


### PR DESCRIPTION
NanoCBOR return values were again changed/fixed to fix documentation, this PR bump the version and adjusts to it as well. It also changes the cmake file to use an explicit commit, this would have been an issue since two different builds would use different commits (potentially).