### PR TITLE
include/edhoc: add sha_ctx_t type

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -8,12 +8,12 @@
 #include <wolfssl/options.h>
 #endif
 #include <wolfssl/wolfcrypt/sha256.h>
-
+    typedef wc_Sha256 sha_ctx_t;
 #elif defined(HACL)
 
 #define HASH_INPUT_BLEN     (256)
 
-typedef struct hacl_Sha256 hacl_Sha256;
+typedef struct hacl_Sha256 sha_ctx_t;
 
 struct hacl_Sha256 {
     uint16_t fillLevel;
@@ -22,6 +22,7 @@ struct hacl_Sha256 {
 #elif defined(EMPTY_CRYPTO)
 #elif defined(TINYCRYPT)
 #include "crypto/tinycrypt/sha256.h"
+    typedef struct tc_sha256_state_struct sha_ctx_t;
 #else
 #error "No crypto backend selected"
 #endif
@@ -48,7 +49,7 @@ int crypt_gen_keypair(cose_curve_t crv, cose_key_t *key);
  * @return On success returns EDHOC_SUCCESS
  * @return On failure returns EDHOC_ERR_CRYPTO
  */
-int crypt_hash_init(void *ctx);
+int crypt_hash_init(sha_ctx_t *ctx);
 
 /**
  * @brief Update the hashing context with
@@ -60,7 +61,7 @@ int crypt_hash_init(void *ctx);
  * @return On success returns EDHOC_SUCCESS
  * @return On failure returns EDHOC_ERR_CRYPTO
  */
-int crypt_hash_update(void *ctx, const uint8_t *in, size_t ilen);
+int crypt_hash_update(sha_ctx_t *ctx, const uint8_t *in, size_t ilen);
 
 /**
  * @brief Finalize a hashing context
@@ -71,7 +72,7 @@ int crypt_hash_update(void *ctx, const uint8_t *in, size_t ilen);
  * @return On success returns EDHOC_SUCCESS
  * @return On failure returns EDHOC_ERR_CRYPTO
  */
-int crypt_hash_finish(void *ctx, uint8_t *out);
+int crypt_hash_finish(sha_ctx_t *ctx, uint8_t *out);
 
 /**
  * @brief Free the hashing context
@@ -79,7 +80,7 @@ int crypt_hash_finish(void *ctx, uint8_t *out);
  * @param[in] digest_ctx    Hashing context
  *
  */
-void crypt_hash_free(void *ctx);
+void crypt_hash_free(sha_ctx_t *ctx);
 
 /**
  * @brief Compute the EDHOC-KDF
@@ -169,7 +170,7 @@ int crypt_decrypt(const cose_key_t *sk,
  * @param srcCtx
  * @return
  */
-int crypt_copy_hash_context(void *dstCtx, void *srcCtx);
+int crypt_copy_hash_context(sha_ctx_t *dstCtx, sha_ctx_t *srcCtx);
 
 /**
  * @brief Compute a signature of the digest

--- a/src/crypto/hacl.c
+++ b/src/crypto/hacl.c
@@ -31,37 +31,36 @@ int crypt_gen_keypair(cose_curve_t crv, cose_key_t *key) {
     return ret;
 }
 
-int crypt_copy_hash_context(void *dstCtx, void *srcCtx) {
-    memcpy(dstCtx, srcCtx, sizeof(hacl_Sha256));
+int crypt_copy_hash_context(sha_ctx_t *dstCtx, sha_ctx_t *srcCtx) {
+    memcpy(dstCtx, srcCtx, sizeof(sha_ctx_t));
     return EDHOC_SUCCESS;
 }
 
-int crypt_hash_init(void *ctx) {
-    (void) ctx;
-    ((hacl_Sha256 *) ctx)->fillLevel = 0;
+int crypt_hash_init(sha_ctx_t *ctx) {
+    ctx->fillLevel = 0;
 
     return EDHOC_SUCCESS;
 }
 
-int crypt_hash_update(void *ctx, const uint8_t *in, size_t ilen) {
-    if (((hacl_Sha256 *) ctx)->fillLevel + ilen > HASH_INPUT_BLEN)
+int crypt_hash_update(sha_ctx_t *ctx, const uint8_t *in, size_t ilen) {
+    if (ctx->fillLevel + ilen > HASH_INPUT_BLEN)
         return EDHOC_ERR_CRYPTO;
 
-    memcpy(((hacl_Sha256 *) ctx)->buffer + ((hacl_Sha256 *) ctx)->fillLevel, in, ilen);
+    memcpy(ctx->buffer + ctx->fillLevel, in, ilen);
 
-    ((hacl_Sha256 *) ctx)->fillLevel += ilen;
+    ctx->fillLevel += ilen;
 
     return EDHOC_SUCCESS;
 }
 
-int crypt_hash_finish(void *ctx, uint8_t *output) {
-    Hacl_Hash_SHA2_hash_256(((hacl_Sha256 *) ctx)->buffer, ((hacl_Sha256 *) ctx)->fillLevel, output);
+int crypt_hash_finish(sha_ctx_t *ctx, uint8_t *output) {
+    Hacl_Hash_SHA2_hash_256(ctx->buffer, ctx->fillLevel, output);
     return EDHOC_SUCCESS;
 }
 
-void crypt_hash_free(void *ctx) {
-    ((hacl_Sha256 *) ctx)->fillLevel = 0;
-    memset(((hacl_Sha256 *) ctx)->buffer, 0, HASH_INPUT_BLEN);
+void crypt_hash_free(sha_ctx_t *ctx) {
+    ctx->fillLevel = 0;
+    memset(ctx->buffer, 0, HASH_INPUT_BLEN);
 }
 
 int crypt_kdf(const uint8_t *prk, const uint8_t *info, size_t infoLen, uint8_t *out, size_t outlen) {
@@ -119,7 +118,7 @@ int crypt_decrypt(const cose_key_t *sk,
                   size_t inOutLen,
                   uint8_t *tag,
                   size_t tagLen) {
-
+    (void) ivLen;
     int ret;
     uint8_t temp[EDHOC_PLAINTEXT23_SIZE];
     size_t tempSize;

--- a/src/crypto/tinycrypt.c
+++ b/src/crypto/tinycrypt.c
@@ -19,36 +19,36 @@ int crypt_gen_keypair(cose_curve_t crv, cose_key_t *key) {
     return EDHOC_ERR_RANDOMNESS;
 }
 
-int crypt_copy_hash_context(void *dstCtx, void *srcCtx) {
-    memcpy(dstCtx, srcCtx, sizeof(struct tc_sha256_state_struct ));
+int crypt_copy_hash_context(sha_ctx_t *dstCtx, sha_ctx_t *srcCtx) {
+    memcpy(dstCtx, srcCtx, sizeof(sha_ctx_t));
 
     return EDHOC_SUCCESS;
 }
 
-int crypt_hash_init(void *ctx) {
+int crypt_hash_init(sha_ctx_t *ctx) {
 
-    if (tc_sha256_init((TCSha256State_t) ctx) == TC_CRYPTO_SUCCESS)
+    if (tc_sha256_init(ctx) == TC_CRYPTO_SUCCESS)
         return EDHOC_SUCCESS;
     else
         return EDHOC_ERR_CRYPTO;
 }
 
-int crypt_hash_update(void *ctx, const uint8_t *in, size_t ilen) {
+int crypt_hash_update(sha_ctx_t *ctx, const uint8_t *in, size_t ilen) {
 
-    if (tc_sha256_update((TCSha256State_t) ctx, in, ilen) == TC_CRYPTO_SUCCESS)
+    if (tc_sha256_update(ctx, in, ilen) == TC_CRYPTO_SUCCESS)
         return EDHOC_SUCCESS;
     else
         return EDHOC_ERR_CRYPTO;
 }
 
-int crypt_hash_finish(void *ctx, uint8_t *output) {
-    if (tc_sha256_final(output, (TCSha256State_t) ctx) == TC_CRYPTO_SUCCESS)
+int crypt_hash_finish(sha_ctx_t *ctx, uint8_t *output) {
+    if (tc_sha256_final(output, ctx) == TC_CRYPTO_SUCCESS)
         return EDHOC_SUCCESS;
     else
         return EDHOC_ERR_CRYPTO;
 }
 
-void crypt_hash_free(void *ctx) {
+void crypt_hash_free(sha_ctx_t *ctx) {
     (void) ctx;
 }
 

--- a/src/crypto/wolfssl.c
+++ b/src/crypto/wolfssl.c
@@ -37,33 +37,33 @@ int crypt_gen_keypair(cose_curve_t crv, cose_key_t *key) {
 }
 
 
-int crypt_copy_hash_context(void *dstCtx, void *srcCtx) {
+int crypt_copy_hash_context(sha_ctx_t *dstCtx, sha_ctx_t *srcCtx) {
     return wc_Sha256Copy(srcCtx, dstCtx);
 }
 
-int crypt_hash_init(void *ctx) {
-    if (wc_InitSha256((wc_Sha256 *) ctx) != EDHOC_SUCCESS)
+int crypt_hash_init(sha_ctx_t *ctx) {
+    if (wc_InitSha256(ctx) != EDHOC_SUCCESS)
         return EDHOC_ERR_CRYPTO;
     else
         return EDHOC_SUCCESS;
 }
 
-int crypt_hash_update(void *ctx, const uint8_t *in, size_t ilen) {
-    if (wc_Sha256Update((wc_Sha256 *) ctx, in, ilen) != EDHOC_SUCCESS)
+int crypt_hash_update(sha_ctx_t *ctx, const uint8_t *in, size_t ilen) {
+    if (wc_Sha256Update(ctx, in, ilen) != EDHOC_SUCCESS)
         return EDHOC_ERR_CRYPTO;
     else
         return EDHOC_SUCCESS;
 }
 
-int crypt_hash_finish(void *ctx, uint8_t *out) {
-    if (wc_Sha256Final((wc_Sha256 *) ctx, out) != EDHOC_SUCCESS)
+int crypt_hash_finish(sha_ctx_t *ctx, uint8_t *out) {
+    if (wc_Sha256Final(ctx, out) != EDHOC_SUCCESS)
         return EDHOC_ERR_CRYPTO;
     else
         return EDHOC_SUCCESS;
 }
 
-void crypt_hash_free(void *ctx) {
-    wc_Sha256Free((wc_Sha256 *) ctx);
+void crypt_hash_free(sha_ctx_t *ctx) {
+    wc_Sha256Free(ctx);
 }
 
 int crypt_kdf(const uint8_t *prk, const uint8_t *info, size_t infoLen, uint8_t *out, size_t olen) {

--- a/src/process.c
+++ b/src/process.c
@@ -29,7 +29,6 @@ static void generate_conn_id(uint8_t *p, size_t *length) {
     *length = cidLen;
 }
 
-
 ssize_t proc_create_msg1(edhoc_ctx_t *ctx, corr_t corr, method_t m, cipher_suite_id_t id, uint8_t *out, size_t olen) {
     ssize_t ret, len;
     ssize_t ad1Len;
@@ -38,16 +37,7 @@ ssize_t proc_create_msg1(edhoc_ctx_t *ctx, corr_t corr, method_t m, cipher_suite
 
     edhoc_msg1_t msg1;
 
-#if defined(WOLFSSL)
-    wc_Sha256 hashCtx;
-#elif defined(HACL)
-    hacl_Sha256 hashCtx;
-#elif defined(TINYCRYPT)
-    struct tc_sha256_state_struct hashCtx;
-#else
-#error "No crypto backend enabled."
-#endif
-
+    sha_ctx_t hashCtx;
     const cipher_suite_t *suiteInfo;
 
     suiteInfo = NULL;
@@ -137,21 +127,8 @@ ssize_t proc_create_msg2(edhoc_ctx_t *ctx, const uint8_t *msg1Buf, size_t msg1Le
     ad_cb_t ad2;
     cred_type_t credType;
 
-#if defined(WOLFSSL)
-    wc_Sha256 hashCtx;
-#elif defined(HACL)
-    hacl_Sha256 hashCtx;
-#elif defined(TINYCRYPT)
-    struct tc_sha256_state_struct hashCtx;
-#else
-#error "No crypto backend enabled"
-#endif
-
-#if defined(NANOCBOR)
-    nanocbor_encoder_t enc;
-#else
-#error "No CBOR backend enabled"
-#endif
+    sha_ctx_t hashCtx;
+    cbor_encoder_t enc;
 
     uint8_t iv2m[EDHOC_IV23M_SIZE] = {0};
     uint8_t mac2[EDHOC_MAC23_SIZE] = {0};
@@ -385,21 +362,8 @@ ssize_t proc_create_msg3(edhoc_ctx_t *ctx, const uint8_t *msg2Buf, size_t msg2Le
     const uint8_t *remoteCred;
     size_t remoteCredLen;
 
-#if defined(WOLFSSL)
-    wc_Sha256 hashCtx;
-#elif defined(HACL)
-    hacl_Sha256 hashCtx;
-#elif defined(TINYCRYPT)
-    struct tc_sha256_state_struct hashCtx;
-#else
-#error "No crypto backend enabled"
-#endif
-
-#if defined(NANOCBOR)
-    nanocbor_encoder_t enc;
-#else
-#error "No CBOR backend enabled"
-#endif
+    sha_ctx_t hashCtx;
+    cbor_encoder_t enc;
 
     uint8_t iv3mOrIv3ae[EDHOC_IV23M_SIZE] = {0};
     uint8_t mac3[EDHOC_MAC23_SIZE] = {0};
@@ -703,21 +667,8 @@ proc_resp_finalize(edhoc_ctx_t *ctx, const uint8_t *msg3Buf, size_t msg3Len, boo
     const uint8_t *remoteCred;
     size_t remoteCredLen;
 
-#if defined(WOLFSSL)
-    wc_Sha256 hashCtx;
-#elif defined(HACL)
-    hacl_Sha256 hashCtx;
-#elif defined(TINYCRYPT)
-    struct tc_sha256_state_struct hashCtx;
-#else
-#error "No crypto backend enabled"
-#endif
-
-#if defined(NANOCBOR)
-    nanocbor_encoder_t enc;
-#else
-#error "No CBOR backend enabled."
-#endif
+    sha_ctx_t hashCtx;
+    cbor_encoder_t enc;
 
     uint8_t iv3ae[EDHOC_IV23M_SIZE] = {0};
     uint8_t temp[EDHOC_PLAINTEXT23_SIZE + EDHOC_MAC23_SIZE] = {0};


### PR DESCRIPTION
This PR adds a typedef for the `sha_ctx_t` to avoid ifdefs and typecasting.